### PR TITLE
Add experiment name & path as separate inputs

### DIFF
--- a/src/lib/components/BottomNavBar.svelte
+++ b/src/lib/components/BottomNavBar.svelte
@@ -5,20 +5,22 @@
 	import BottomNavItemNew from '$lib/components/BottomNavItemNew.svelte';
 	import BottomNavItemSave from '$lib/components/BottomNavItemSave.svelte';
 	import { BottomNav, Tooltip } from 'flowbite-svelte';
-	import { type Sample } from '$lib/util';
+	import { type Experiment, type Sample } from '$lib/util';
 
 	let {
-		samples = $bindable([])
+		samples = $bindable([]),
+		experiment = $bindable(),
 	}: {
 		samples: Array<Sample>;
+		experiment: Experiment;
 	} = $props();
 </script>
 
 <BottomNav position="fixed" navType="border" classes={{ inner: 'grid-cols-3' }}>
-	<BottomNavItemNew bind:samples />
+	<BottomNavItemNew bind:samples bind:experiment/>
 	<Tooltip arrow={false}>Create a new sample-sheet</Tooltip>
-	<BottomNavItemOpen bind:samples />
+	<BottomNavItemOpen bind:samples bind:experiment/>
 	<Tooltip arrow={false}>Open an existing sample-sheet</Tooltip>
-	<BottomNavItemSave bind:samples />
+	<BottomNavItemSave bind:samples bind:experiment/>
 	<Tooltip arrow={false}>Save the sample-sheet</Tooltip>
 </BottomNav>

--- a/src/lib/components/BottomNavItemNew.svelte
+++ b/src/lib/components/BottomNavItemNew.svelte
@@ -3,16 +3,19 @@
 <script lang="ts">
 	import { FileCirclePlusSolid } from 'flowbite-svelte-icons';
 	import { BottomNavItem } from 'flowbite-svelte';
-	import { makeDefaultSample, type Sample } from '$lib/util';
+	import { type Experiment, makeDefaultExperiment, makeDefaultSample, type Sample } from '$lib/util';
 
 	let {
-		samples = $bindable([])
+		samples = $bindable([]),
+		experiment = $bindable()
 	}: {
 		samples: Array<Sample>;
+		experiment: Experiment;
 	} = $props();
 
 	function onclick() {
 		samples = [makeDefaultSample()];
+		experiment = makeDefaultExperiment();
 	}
 </script>
 

--- a/src/lib/components/BottomNavItemOpen.svelte
+++ b/src/lib/components/BottomNavItemOpen.svelte
@@ -3,12 +3,14 @@
 <script lang="ts">
 	import { FileImportSolid } from 'flowbite-svelte-icons';
 	import { BottomNavItem } from 'flowbite-svelte';
-	import { type Sample, makeEmptySample } from '$lib/util';
+	import { type Sample, makeEmptySample, type Experiment, type TsvRow, makeEmptyExperiment } from '$lib/util';
 
 	let {
-		samples = $bindable([])
+		samples = $bindable([]),
+		experiment = $bindable()
 	}: {
 		samples: Array<Sample>;
+		experiment: Experiment;
 	} = $props();
 
 	let files: FileList | undefined = $state(undefined);
@@ -25,11 +27,22 @@
 			}
 			const headers = lines[0];
 			for (const line of lines.slice(1)) {
-				const sample: Sample = makeEmptySample();
+				// read tsv row
+				let tsvRow: Record<string, string> = {};
 				for (let j = 0; j < Math.min(headers.length, line.length); j++) {
-					sample[headers[j]] = line[j];
+					tsvRow[headers[j]] = line[j];
+				}
+				// create empty sample and update with data from row
+				const sample: Sample = makeEmptySample();
+				for (const key of Object.keys(sample)) {
+					sample[key as keyof Sample] = tsvRow?.[key];
 				}
 				samples.push(sample as Sample);
+				// create empty experiment and update with data from row
+				experiment = makeEmptyExperiment();
+				for (const key of Object.keys(experiment)) {
+					experiment[key as keyof Experiment] = tsvRow?.[key];
+				}
 			}
 		}
 	}

--- a/src/lib/components/BottomNavItemSave.svelte
+++ b/src/lib/components/BottomNavItemSave.svelte
@@ -4,21 +4,28 @@
 	import { FloppyDiskSolid } from 'flowbite-svelte-icons';
 	import { BottomNavItem } from 'flowbite-svelte';
 	import FileSaver from 'file-saver';
-	import { sampleHeaders, type Sample } from '$lib/util';
+	import { tsvHeaders, type Sample, type Experiment, type TsvRow } from '$lib/util';
 
 	let {
-		samples = $bindable([])
+		samples = $bindable([]),
+		experiment = $bindable()
 	}: {
 		samples: Array<Sample>;
+		experiment: Experiment;
 	} = $props();
 
 	function onclick() {
-		let lines = [sampleHeaders.join('\t')];
+		let lines = [tsvHeaders.join('\t')];
 		for (const sample of samples) {
+			let tsvRow = sample as TsvRow;
+			// set experiment data that applies to all samples
+			for(const [key, value] of Object.entries(experiment) ) {
+				tsvRow[key as keyof Experiment] = value;
+			}
 			lines.push(
-				sampleHeaders
+				tsvHeaders
 					.map((header) => {
-						return sample[header as keyof Sample] ?? '';
+						return tsvRow[header] ?? '';
 					})
 					.join('\t')
 			);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -3,10 +3,13 @@ const nRows = 8;
 
 type SeqType = 'p5' | 'p7' | 'rt';
 
-type Sample = {
-	path_fastq?: string;
-	path_bcl?: string;
+type Experiment = {
 	experiment_name: string;
+	path_fastq: string;
+	path_bcl: string;
+}
+
+type Sample = {
 	sample_name: string;
 	species: string;
 	n_expected_cells: string;
@@ -16,7 +19,9 @@ type Sample = {
 	hashing?: string;
 };
 
-const sampleHeaders = [
+type TsvRow = Experiment & Sample;
+
+const tsvHeaders: Array<keyof TsvRow> = [
 	'path_fastq',
 	'path_bcl',
 	'experiment_name',
@@ -31,9 +36,6 @@ const sampleHeaders = [
 
 function makeDefaultSample(): Sample {
 	return {
-		path_fastq: 'data',
-		path_bcl: 'data',
-		experiment_name: 'experiment',
 		sample_name: 'sample',
 		species: 'mouse',
 		n_expected_cells: '100',
@@ -44,10 +46,16 @@ function makeDefaultSample(): Sample {
 	};
 }
 
+function makeDefaultExperiment() {
+	return { path_fastq: '/data', path_bcl: '/data', experiment_name: 'experiment' };
+}
+
+function makeEmptyExperiment() {
+	return { path_fastq: '', path_bcl: '', experiment_name: '' };
+}
+
 function makeEmptySample(): Sample {
 	return {
-		path_fastq: '',
-		experiment_name: '',
 		sample_name: '',
 		species: '',
 		n_expected_cells: '',
@@ -155,11 +163,15 @@ function additionalSelectionValid(
 }
 
 export {
+	type Experiment,
 	type Sample,
 	type SeqType,
+	type TsvRow,
 	parse,
-	sampleHeaders,
+	tsvHeaders,
 	makeDefaultSample,
+	makeDefaultExperiment,
+	makeEmptyExperiment,
 	makeEmptySample,
 	additionalSelectionValid
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,40 +2,50 @@
 
 <script lang="ts">
 	import Plate from '$lib/components/Plate.svelte';
-	import { Banner, Label, Input, Tabs, TabItem, Button } from 'flowbite-svelte';
+	import { Banner, Label, Input, AccordionItem, Accordion, Button } from 'flowbite-svelte';
 	import { CirclePlusOutline } from 'flowbite-svelte-icons';
 	import BottomNavBar from '$lib/components/BottomNavBar.svelte';
-	import { makeDefaultSample } from '$lib/util';
+	import { makeDefaultExperiment, makeDefaultSample } from '$lib/util';
 	import favicon from '$lib/assets/favicon.jpeg';
 
 	let samples = $state([makeDefaultSample()]);
+	let experiment = $state(makeDefaultExperiment());
 </script>
 
 <Banner dismissable={false} class="fixed bg-[#d2d2d2]">
 	<img src={favicon} alt="sci-rocket" class="absolute top-0 left-2 h-14" />
-	<h1 class="font-bold">sci-rocket sample-sheet editor</h1>
+	<h1 class="font-bold">{experiment.experiment_name}</h1>
 </Banner>
-<div class="my-20">
-	<Tabs>
+<div class="my-20 p-4">
+	<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 pb-4">
+		<div>
+			<Label>
+				Experiment name
+				<Input bind:value={experiment.experiment_name} />
+			</Label>
+		</div>
+		<div>
+			<Label>
+				Path BCL
+				<Input bind:value={experiment.path_bcl} />
+			</Label>
+		</div>
+		<div>
+			<Label>
+				Path FASTQ
+				<Input bind:value={experiment.path_fastq} />
+			</Label>
+		</div>
+	</div>
+	<Accordion multiple>
 		{#each samples as sample, sample_index (sample_index)}
-			<TabItem title={sample.sample_name} open={sample_index === 0}>
-				<div class="flex flex-col space-y-4 p-4">
+			<AccordionItem open>
+				{#snippet header()}{sample.sample_name}{/snippet}
+				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 pb-4">
 					<div>
 						<Label>
 							Sample name
 							<Input bind:value={sample.sample_name} />
-						</Label>
-					</div>
-					<div>
-						<Label>
-							Path
-							<Input bind:value={sample.path_fastq} />
-						</Label>
-					</div>
-					<div>
-						<Label>
-							Experiment name
-							<Input bind:value={sample.experiment_name} />
 						</Label>
 					</div>
 					<div>
@@ -56,15 +66,15 @@
 							<Input bind:value={sample.hashing} />
 						</Label>
 					</div>
-					<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-4">
-						<Plate bind:str={sample.p5} type="p5" />
-						<Plate bind:str={sample.p7} type="p7" />
-						<!-- TODO: Can there be more than two plates for RT? -->
-						<Plate bind:str={sample.rt} type="rt" plate_index={0} />
-						<Plate bind:str={sample.rt} type="rt" plate_index={1} />
-					</div>
 				</div>
-			</TabItem>
+				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-4">
+					<Plate bind:str={sample.p5} type="p5" />
+					<Plate bind:str={sample.p7} type="p7" />
+					<!-- TODO: Can there be more than two plates for RT? -->
+					<Plate bind:str={sample.rt} type="rt" plate_index={0} />
+					<Plate bind:str={sample.rt} type="rt" plate_index={1} />
+				</div>
+			</AccordionItem>
 		{/each}
 		<Button
 			class="m-2"
@@ -76,6 +86,6 @@
 		>
 			<CirclePlusOutline class="me-2 h-5 w-5" /> Add sample
 		</Button>
-	</Tabs>
+	</Accordion>
 </div>
-<BottomNavBar bind:samples />
+<BottomNavBar bind:samples bind:experiment />


### PR DESCRIPTION
- these experiment inputs get applied to every row of the generated tsv
- add path_bcl input
- replace tabs with accordian
- use two cols on larger screens for text inputs
- resolves #12
