### PR TITLE
Automatically calculate number of cells

### DIFF
--- a/src/lib/components/BottomNavBar.svelte
+++ b/src/lib/components/BottomNavBar.svelte
@@ -10,17 +10,19 @@
 	let {
 		samples = $bindable([]),
 		experiment = $bindable(),
+		num_plates = $bindable()
 	}: {
 		samples: Array<Sample>;
 		experiment: Experiment;
+		num_plates: number;
 	} = $props();
 </script>
 
 <BottomNav position="fixed" navType="border" classes={{ inner: 'grid-cols-3' }}>
-	<BottomNavItemNew bind:samples bind:experiment/>
+	<BottomNavItemNew bind:samples bind:experiment bind:num_plates />
 	<Tooltip arrow={false}>Create a new sample-sheet</Tooltip>
-	<BottomNavItemOpen bind:samples bind:experiment/>
+	<BottomNavItemOpen bind:samples bind:experiment bind:num_plates />
 	<Tooltip arrow={false}>Open an existing sample-sheet</Tooltip>
-	<BottomNavItemSave bind:samples bind:experiment/>
+	<BottomNavItemSave bind:samples bind:experiment />
 	<Tooltip arrow={false}>Save the sample-sheet</Tooltip>
 </BottomNav>

--- a/src/lib/components/BottomNavItemNew.svelte
+++ b/src/lib/components/BottomNavItemNew.svelte
@@ -3,19 +3,27 @@
 <script lang="ts">
 	import { FileCirclePlusSolid } from 'flowbite-svelte-icons';
 	import { BottomNavItem } from 'flowbite-svelte';
-	import { type Experiment, makeDefaultExperiment, makeDefaultSample, type Sample } from '$lib/util';
+	import {
+		type Experiment,
+		makeDefaultExperiment,
+		makeDefaultSample,
+		type Sample
+	} from '$lib/util';
 
 	let {
 		samples = $bindable([]),
-		experiment = $bindable()
+		experiment = $bindable(),
+		num_plates = $bindable()
 	}: {
 		samples: Array<Sample>;
 		experiment: Experiment;
+		num_plates: number;
 	} = $props();
 
 	function onclick() {
 		samples = [makeDefaultSample()];
 		experiment = makeDefaultExperiment();
+		num_plates = 1;
 	}
 </script>
 

--- a/src/lib/components/BottomNavItemSave.svelte
+++ b/src/lib/components/BottomNavItemSave.svelte
@@ -4,7 +4,7 @@
 	import { FloppyDiskSolid } from 'flowbite-svelte-icons';
 	import { BottomNavItem } from 'flowbite-svelte';
 	import FileSaver from 'file-saver';
-	import { tsvHeaders, type Sample, type Experiment, type TsvRow } from '$lib/util';
+	import { tsvHeaders, type Sample, type Experiment, type TsvRow, count_rt_wells } from '$lib/util';
 
 	let {
 		samples = $bindable([]),
@@ -19,9 +19,13 @@
 		for (const sample of samples) {
 			let tsvRow = sample as TsvRow;
 			// set experiment data that applies to all samples
-			for(const [key, value] of Object.entries(experiment) ) {
+			for (const [key, value] of Object.entries(experiment)) {
 				tsvRow[key as keyof Experiment] = value;
 			}
+			// calculate number of cells
+			tsvRow.n_expected_cells = Math.floor(
+				tsvRow.cells_per_well * count_rt_wells(tsvRow.rt)
+			).toString();
 			lines.push(
 				tsvHeaders
 					.map((header) => {

--- a/src/lib/util.spec.ts
+++ b/src/lib/util.spec.ts
@@ -1,8 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { parse } from '$lib/util';
+import { parse, count_rt_wells, count_rt_plates } from '$lib/util';
+
+function count_true(array: Array<Array<boolean>>): number {
+	return array.flat().filter((e) => e).length;
+}
 
 describe('parse', () => {
-	it('valid p5 cells', () => {
+	it('empty strings', () => {
+		expect(count_true(parse('', 'p5'))).toBe(0);
+		expect(count_true(parse('', 'p7'))).toBe(0);
+		expect(count_true(parse('', 'rt', 0))).toBe(0);
+		expect(count_true(parse('', 'rt', 1))).toBe(0);
+		expect(count_true(parse('', 'rt', 2))).toBe(0);
+	});
+	it('valid p5 wells', () => {
 		const a = parse('A02,H03', 'p5');
 		// A02
 		expect(a[0][0]).toBe(false);
@@ -12,8 +23,10 @@ describe('parse', () => {
 		expect(a[7][1]).toBe(false);
 		expect(a[7][2]).toBe(true);
 		expect(a[7][3]).toBe(false);
+		// 2 selected wells
+		expect(count_true(a)).toBe(2);
 	});
-	it('valid p7 cells', () => {
+	it('valid p7 wells', () => {
 		const a = parse('A02,H03', 'p7');
 		// A02
 		expect(a[0][0]).toBe(false);
@@ -23,6 +36,8 @@ describe('parse', () => {
 		expect(a[7][1]).toBe(false);
 		expect(a[7][2]).toBe(true);
 		expect(a[7][3]).toBe(false);
+		// 2 selected wells
+		expect(count_true(a)).toBe(2);
 	});
 	it('valid p5 cols', () => {
 		const a = parse('A02:C02,B10:G10', 'p5');
@@ -45,8 +60,48 @@ describe('parse', () => {
 		expect(a[5][9]).toBe(true);
 		expect(a[6][9]).toBe(true);
 		expect(a[7][9]).toBe(false);
+		// 9 selected wells
+		expect(count_true(a)).toBe(9);
 	});
 	// todo: add tests that p7 col or p5 row or p5/p7 rectangles are rejected as invalid
 	// todo: more invalid inputs
 	// todo: rt tests
+});
+
+describe('count', () => {
+	it('empty string: 0 wells, 1 plate', () => {
+		const str = '';
+		expect(count_rt_plates(str)).toBe(1);
+		expect(count_rt_wells(str)).toBe(0);
+	});
+	it('one well in plate 1: 1 well, 1 plate', () => {
+		const str = 'P01-A02';
+		expect(count_rt_plates(str)).toBe(1);
+		expect(count_rt_wells(str)).toBe(1);
+	});
+	it('one well in plate 3: 1 well, 3 plates', () => {
+		const str = 'P03-C09';
+		expect(count_rt_plates(str)).toBe(3);
+		expect(count_rt_wells(str)).toBe(1);
+	});
+	it('four wells in plate 1: 4 wells, 1 plate', () => {
+		const str = 'P01-A02,P01-C07,P01-H11,P01-F07';
+		expect(count_rt_plates(str)).toBe(1);
+		expect(count_rt_wells(str)).toBe(4);
+	});
+	it('two rows in 2 plates: 24 wells, 2 plates', () => {
+		const str = 'P01-A01:P01-A12,P02-H01:P02-H12';
+		expect(count_rt_plates(str)).toBe(2);
+		expect(count_rt_wells(str)).toBe(24);
+	});
+	it('two cols in 1 plate: 16 wells, 1 plate', () => {
+		const str = 'P01-A01:P01-H01,P01-A09:P01-H09';
+		expect(count_rt_plates(str)).toBe(1);
+		expect(count_rt_wells(str)).toBe(16);
+	});
+	it('all wells in 4 plates: 384 well, 4 plates', () => {
+		const str = 'P01-A01:P01-H12,P02-A01:P02-H12,P03-A01:P03-H12,P04-A01:P04-H12';
+		expect(count_rt_plates(str)).toBe(4);
+		expect(count_rt_wells(str)).toBe(384);
+	});
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,10 @@
 
 	let samples = $state([makeDefaultSample()]);
 	let experiment = $state(makeDefaultExperiment());
+	let num_plates = $state(1);
+	let plates_indices = $derived(
+		num_plates > 0 ? Array.from({ length: num_plates }, (_, i) => i) : [0]
+	);
 </script>
 
 <Banner dismissable={false} class="fixed bg-[#d2d2d2]">
@@ -17,11 +21,17 @@
 	<h1 class="font-bold">{experiment.experiment_name}</h1>
 </Banner>
 <div class="my-20 p-4">
-	<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 pb-4">
+	<div class="grid grid-cols-1 gap-4 pb-4 lg:grid-cols-2">
 		<div>
 			<Label>
 				Experiment name
 				<Input bind:value={experiment.experiment_name} />
+			</Label>
+		</div>
+		<div>
+			<Label>
+				Number of plates
+				<Input bind:value={num_plates} type="number" />
 			</Label>
 		</div>
 		<div>
@@ -41,7 +51,7 @@
 		{#each samples as sample, sample_index (sample_index)}
 			<AccordionItem open>
 				{#snippet header()}{sample.sample_name}{/snippet}
-				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 pb-4">
+				<div class="grid grid-cols-1 gap-4 pb-4 lg:grid-cols-2">
 					<div>
 						<Label>
 							Sample name
@@ -56,8 +66,8 @@
 					</div>
 					<div>
 						<Label>
-							Num expected cells
-							<Input bind:value={sample.n_expected_cells} />
+							Cells per well
+							<Input type="number" bind:value={sample.cells_per_well} />
 						</Label>
 					</div>
 					<div>
@@ -70,9 +80,9 @@
 				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-4">
 					<Plate bind:str={sample.p5} type="p5" />
 					<Plate bind:str={sample.p7} type="p7" />
-					<!-- TODO: Can there be more than two plates for RT? -->
-					<Plate bind:str={sample.rt} type="rt" plate_index={0} />
-					<Plate bind:str={sample.rt} type="rt" plate_index={1} />
+					{#each plates_indices as plate_index}
+						<Plate bind:str={sample.rt} type="rt" {plate_index} />
+					{/each}
 				</div>
 			</AccordionItem>
 		{/each}
@@ -88,4 +98,4 @@
 		</Button>
 	</Accordion>
 </div>
-<BottomNavBar bind:samples bind:experiment />
+<BottomNavBar bind:samples bind:experiment bind:num_plates />


### PR DESCRIPTION
- user enters number of cells per well for each sample
  - n_expected_cells = this number multiplied by the number of selected RT wells
- when a sample sheet is loaded, cells per well is calculated by dividing n_expected_cells by the number of selected RT wells
- allow user to select how many plates are visible
  - this is set automatically on load so that all the selected wells are visible
- extend tests
- resolves #10